### PR TITLE
fix(controller): use curl exec readiness probe for HTTPS with self-si…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+FROM golang:1.26.4-alpine3.23@sha256:18b460dd17542c2ba43299a633cf6ebfc1115101509531471d7cfce1019af083 AS builder
 
 WORKDIR /operator
 
@@ -28,7 +28,7 @@ COPY ./hack/ ./hack/
 RUN make build
 RUN cp ./bin/iofog-operator /bin
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6@sha256:34880b64c07f28f64d95737f82f891516de9a3b43583f39970f7bf8e4cfa48b7
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8@sha256:c5478a52c410e71c53839923c83a1480199a1e74ce5736fe3e3a5578dc399102
 WORKDIR /
 
 ARG OCI_SOURCE_REPO=https://github.com/eclipse-iofog/iofog-operator

--- a/controllers/controlplanes/microservices.go
+++ b/controllers/controlplanes/microservices.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -454,6 +455,34 @@ func filterControllerConfig(cfg *controllerMicroserviceConfig) {
 	}
 }
 
+func controllerReadinessProbe(cfg *controllerMicroserviceConfig) *corev1.Probe {
+	probe := &corev1.Probe{
+		InitialDelaySeconds: 10,
+		TimeoutSeconds:      10,
+		PeriodSeconds:       5,
+		FailureThreshold:    2,
+	}
+
+	if cfg.https != nil && *cfg.https {
+		statusURL := fmt.Sprintf("https://127.0.0.1:%d/api/v3/status", controllerAPIPort)
+		probe.ProbeHandler = corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"curl", "-sfk", statusURL},
+			},
+		}
+		return probe
+	}
+
+	probe.ProbeHandler = corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path:   "/api/v3/status",
+			Port:   intstr.FromInt(controllerAPIPort),
+			Scheme: corev1.URISchemeHTTP,
+		},
+	}
+	return probe
+}
+
 func getControllerPort(msvc *microservice) (int, error) {
 	if len(msvc.services) == 0 || len(msvc.services[0].ports) == 0 {
 		return 0, errors.New("controller microservice does not have requisite ports")
@@ -534,20 +563,8 @@ func newControllerMicroservice(namespace string, cfg *controllerMicroserviceConf
 				name:            "controller",
 				image:           cfg.image,
 				imagePullPolicy: "Always",
-				readinessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/api/v3/status",
-							Port:   intstr.FromInt(51121), //nolint:gomnd
-							Scheme: corev1.URIScheme(strings.ToUpper(cfg.scheme)),
-						},
-					},
-					InitialDelaySeconds: 10,
-					TimeoutSeconds:      10,
-					PeriodSeconds:       5,
-					FailureThreshold:    2,
-				},
-				volumeMounts: []corev1.VolumeMount{},
+				readinessProbe:  controllerReadinessProbe(cfg),
+				volumeMounts:    []corev1.VolumeMount{},
 				env: []corev1.EnvVar{
 					{
 						Name:  "DB_PROVIDER",

--- a/controllers/controlplanes/microservices_controller_test.go
+++ b/controllers/controlplanes/microservices_controller_test.go
@@ -1,10 +1,13 @@
 package controllers
 
 import (
+	"fmt"
 	"testing"
 
 	cpv3 "github.com/eclipse-iofog/iofog-operator/v3/apis/controlplanes/v3"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestNewControllerMicroservice_ExposesAPIAndConsoleServicePorts(t *testing.T) {
@@ -44,6 +47,46 @@ func TestNewControllerMicroservice_ConsolePortFromCR(t *testing.T) {
 		}
 	}
 	require.Equal(t, "9000", consoleEnv)
+}
+
+func TestControllerReadinessProbe_HTTPUsesHTTPGet(t *testing.T) {
+	probe := controllerReadinessProbe(&controllerMicroserviceConfig{})
+
+	require.NotNil(t, probe.HTTPGet)
+	require.Nil(t, probe.Exec)
+	require.Equal(t, "/api/v3/status", probe.HTTPGet.Path)
+	require.Equal(t, corev1.URISchemeHTTP, probe.HTTPGet.Scheme)
+	require.Equal(t, int32(controllerAPIPort), probe.HTTPGet.Port.IntVal)
+}
+
+func TestControllerReadinessProbe_HTTPSUsesCurlExec(t *testing.T) {
+	probe := controllerReadinessProbe(&controllerMicroserviceConfig{https: ptr.To(true)})
+
+	require.NotNil(t, probe.Exec)
+	require.Nil(t, probe.HTTPGet)
+	require.Equal(t, []string{
+		"curl",
+		"-sfk",
+		fmt.Sprintf("https://127.0.0.1:%d/api/v3/status", controllerAPIPort),
+	}, probe.Exec.Command)
+}
+
+func TestNewControllerMicroservice_ReadinessProbeMatchesHTTPSConfig(t *testing.T) {
+	base := &controllerMicroserviceConfig{
+		replicas: 1,
+		db:       &cpv3.Database{Provider: "postgres"},
+		auth:     &cpv3.Auth{Mode: cpv3.AuthModeEmbedded},
+	}
+
+	msHTTP := newControllerMicroservice("cp-ns", base)
+	require.NotNil(t, msHTTP.containers[0].readinessProbe.HTTPGet)
+	require.Nil(t, msHTTP.containers[0].readinessProbe.Exec)
+
+	cfgHTTPS := *base
+	cfgHTTPS.https = ptr.To(true)
+	msHTTPS := newControllerMicroservice("cp-ns", &cfgHTTPS)
+	require.NotNil(t, msHTTPS.containers[0].readinessProbe.Exec)
+	require.Nil(t, msHTTPS.containers[0].readinessProbe.HTTPGet)
 }
 
 func TestNewControllerMicroservice_ConsoleURLFromCR(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/eclipse-iofog/iofog-operator/v3
 go 1.26.4
 
 require (
-	github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.0-rc.2
+	github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.0-rc.9
 	github.com/go-logr/logr v1.4.2
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.32.1
@@ -34,6 +34,7 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -47,6 +48,8 @@ require (
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
@@ -61,7 +64,6 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.0-rc.2 h1:OKVzEEXn74xwAXpXmZCHUZpqF6bI7JTZMxo9fbhBNFo=
-github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.0-rc.2/go.mod h1:MU+YPxFRGFzBMboi1khtEGAoRwaF4yJX3KuBwFcfCKg=
+github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.0-rc.9 h1:jO1lJ6vhTWt09zGrT2Ds5+edl6q/Ggf9RaD0arYuxMQ=
+github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.0-rc.9/go.mod h1:9ae5lnGma/LDsrW/25QOt4aQ3pC9aM0c3ut3N3BwDWM=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=
@@ -51,6 +51,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -103,6 +105,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -165,8 +171,6 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
…gned TLS

Kubelet httpGet probes verify TLS strictly and fail on private/self-signed controller certs. When spec.controller.https is true, probe via curl -sfk against loopback instead; keep httpGet for plain HTTP. Also bump Dockerfile base images to latest multi-arch index digests (golang 1.26.4-alpine3.23, ubi9-minimal 9.8) and ioFog Go SDK to v3.8.0-rc.9.