### PR TITLE
chore(release): bump to 3.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.5'
   VERSION_TAG: ci-${{ github.run_id }}
 
 jobs:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -11,7 +11,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.5'
 
 jobs:
   govulncheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.5'
   OPERATOR_SDK_VERSION: v1.37.0
 
 jobs:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 # golangci-lint configuration for ioFog Operator
-# Target: Go 1.26.4, module github.com/eclipse-iofog/iofog-operator/v3
+# Target: Go 1.26.5, module github.com/eclipse-iofog/iofog-operator/v3
 
 version: "2"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.8.0] - TBD
+## [3.8.1] - 2026-07-10
+
+### Changed
+
+- **Go toolchain** - Go **1.26.5** (from 1.26.4) in `go.mod`, Dockerfile builder image, and CI workflows.
+- **iofog-go-sdk** - bumped to **`github.com/eclipse-iofog/iofog-go-sdk/v3@v3.8.1`**.
+- **Default component image tags** - operator, controller, and router **3.8.1**; NATS **2.14.3-1** (Makefile `LDFLAGS`, Helm `values.yaml`, OLM bundle CSV).
+- **Release packaging** - Helm chart `version` / `appVersion`, `VERSION_TAG` defaults, and install docs updated to **3.8.1**.
+
+### Fixed
+
+- **NATS default image tag** - `NATS_IMAGE_TAG` and Helm defaults now use **`2.14.3-1`** instead of the incorrect **`3.8.0`** component-train tag.
+
+## [3.8.0] - End of June 2026
 
 ### Added
 
@@ -166,7 +179,8 @@ See [README.md](README.md) for install examples and dual-mirror workflow.
 - Consolidate usage of iofog client and reorganize controller reconciliation
 - Removes all references to Connector
 
-[Unreleased]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.8.1...HEAD
+[3.8.1]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.8.0...v3.8.1
 [3.8.0]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.0.0...v3.8.0
 [3.0.0]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.0.0-beta1...v3.0.0
 [3.0.0-beta1]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.0.0-alpha2...v3.0.0-beta1

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -33,7 +33,7 @@ Typical flow:
 
 | Tool | Version |
 |------|---------|
-| Go | **1.26.4** (see `go.mod`) |
+| Go | **1.26.5** (see `go.mod`) |
 | Kubernetes | **1.22+** for cluster testing |
 | Helm | **3.x** (for chart work) |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.23@sha256:18b460dd17542c2ba43299a633cf6ebfc1115101509531471d7cfce1019af083 AS builder
+FROM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS builder
 
 WORKDIR /operator
 

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ OPERATOR_CRD_GROUP ?= iofog.org
 OPERATOR_COMPONENT_LABEL_DOMAIN ?= iofog.org
 IMAGE_REGISTRY ?= ghcr.io/eclipse-iofog
 
-# Default component image tags (RFC R10: ghcr.io/eclipse-iofog/*:3.8.0)
-CONTROLLER_IMAGE_TAG ?= 3.8.0
-ROUTER_IMAGE_TAG ?= 3.8.0
-NATS_IMAGE_TAG ?= 3.8.0
+# Default component image tags (RFC R10: ghcr.io/eclipse-iofog/*:3.8.1)
+CONTROLLER_IMAGE_TAG ?= 3.8.1
+ROUTER_IMAGE_TAG ?= 3.8.1
+NATS_IMAGE_TAG ?= 2.14.3-1
 
 LDFLAGS += -X $(PREFIX).routerTag=$(ROUTER_IMAGE_TAG)
 LDFLAGS += -X $(PREFIX).controllerTag=$(CONTROLLER_IMAGE_TAG)
@@ -45,7 +45,7 @@ GOARGS=-gcflags="all=-N -l"
 endif
 
 # Image URL to use all building/pushing image targets
-VERSION_TAG ?= 3.8.0
+VERSION_TAG ?= 3.8.1
 IMG ?= $(IMAGE_REGISTRY)/operator:$(VERSION_TAG)
 BUNDLE_IMG ?= $(IMAGE_REGISTRY)/operator-bundle:$(VERSION_TAG)
 BUNDLE_PACKAGE ?= iofog-operator
@@ -126,7 +126,7 @@ local-scenarios: ## Run E2E scenarios A, B, C in order (operator must be running
 
 .PHONY: local-deploy-operator
 local-deploy-operator: kustomize create-namespace ## Deploy published operator image (IMG) into TEST_NAMESPACE
-	@test -n "$(IMG)" || (echo "IMG is required, e.g. IMG=ghcr.io/datasance/operator:3.8.0-beta.1" && exit 1)
+	@test -n "$(IMG)" || (echo "IMG is required, e.g. IMG=ghcr.io/datasance/operator:3.8.1" && exit 1)
 	bash $(LOCAL_SCRIPTS)/deploy-operator.sh
 
 .PHONY: local-e2e-setup

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/eclipse-iofog/iofog-operator/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/eclipse-iofog/iofog-operator/actions/workflows/ci.yml)
 [![Release](https://github.com/eclipse-iofog/iofog-operator/actions/workflows/release.yml/badge.svg)](https://github.com/eclipse-iofog/iofog-operator/actions/workflows/release.yml)
-[![Go](https://img.shields.io/badge/Go-1.26.4-blue.svg)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.26.5-blue.svg)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-EPL--2.0-blue.svg)](LICENSE)
 [![govulncheck](https://github.com/eclipse-iofog/iofog-operator/actions/workflows/govulncheck.yml/badge.svg)](https://github.com/eclipse-iofog/iofog-operator/actions/workflows/govulncheck.yml)
 
@@ -24,7 +24,7 @@ Identical git tree; registry, CRD API group, and Helm index URL differ by mirror
 | Eclipse ioFog (upstream) | `ghcr.io/eclipse-iofog/operator` | `ghcr.io/eclipse-iofog/operator-bundle` |
 | Datasance (PoT-facing) | `ghcr.io/datasance/operator` | `ghcr.io/datasance/operator-bundle` |
 
-Release tags use the semver without a `v` prefix (e.g. `:3.8.0`). Images, manifest tarballs, OLM bundles, and Helm charts publish on **`v*` tags** from each mirror's `release.yml`.
+Release tags use the semver without a `v` prefix (e.g. `:3.8.1`). Images, manifest tarballs, OLM bundles, and Helm charts publish on **`v*` tags** from each mirror's `release.yml`.
 
 ## Dual-mirror workflow
 
@@ -40,12 +40,12 @@ See [CONTRIBUTING](CONTRIBUTING) for CI repository variables and contributor wor
 | Tool | Version |
 |------|---------|
 | Kubernetes | **1.22+** |
-| Go | **1.26.4** (see `go.mod`) |
+| Go | **1.26.5** (see `go.mod`) |
 | Helm | **3.x** (for Helm install) |
 
 ## Greenfield release (v3.8)
 
-**v3.8.0 is a greenfield release.** There is no in-place upgrade path from v3.7. Uninstall the legacy operator and CRDs before installing v3.8. The v3.8 operator manages **ControlPlane** resources only; the Application CRD and legacy auth fields are removed.
+**v3.8.1 is a greenfield release.** There is no in-place upgrade path from v3.7. Uninstall the legacy operator and CRDs before installing v3.8. The v3.8 operator manages **ControlPlane** resources only; the Application CRD and legacy auth fields are removed.
 
 ## Installation
 
@@ -66,7 +66,7 @@ helm repo add iofog-operator https://eclipse-iofog.github.io/iofog-operator
 helm repo update
 helm install iofog-operator iofog-operator/iofog-operator \
   --namespace iofog-system --create-namespace \
-  --version 3.8.0
+  --version 3.8.1
 ```
 
 ### Manifest tarballs
@@ -74,7 +74,7 @@ helm install iofog-operator iofog-operator/iofog-operator \
 GitHub Releases attach flavor-specific tarballs: `manifests-iofog-<version>.tar.gz` and `manifests-datasance-<version>.tar.gz`.
 
 ```bash
-VERSION=3.8.0
+VERSION=3.8.1
 FLAVOR=iofog   # or datasance
 
 curl -fsSL -o manifests.tar.gz \
@@ -92,7 +92,7 @@ OLM bundles are published as container images (`operator-bundle:<version>`). Pac
 
 ```bash
 # Cluster must have OLM installed (Operator Lifecycle Manager)
-VERSION=3.8.0
+VERSION=3.8.1
 REGISTRY=ghcr.io/eclipse-iofog   # or ghcr.io/datasance
 
 operator-sdk run bundle "${REGISTRY}/operator-bundle:${VERSION}" \

--- a/bundle/manifests/iofog-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/iofog-operator.clusterserviceversion.yaml
@@ -119,10 +119,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-07-03T20:16:11Z"
+    createdAt: "2026-07-10T08:57:30Z"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: iofog-operator.v3.8.0
+  name: iofog-operator.v3.8.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -170,7 +170,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: iofog-operator
-                image: ghcr.io/eclipse-iofog/operator:3.8.0
+                image: ghcr.io/eclipse-iofog/operator:3.8.1
                 imagePullPolicy: Always
                 name: iofog-operator
                 resources: {}
@@ -196,4 +196,4 @@ spec:
   minKubeVersion: 1.18.0
   provider:
     name: Datasance
-  version: 3.8.0
+  version: 3.8.1

--- a/charts/iofog-operator/Chart.yaml
+++ b/charts/iofog-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: iofog-operator
 description: Helm chart for the ioFog operator and ControlPlane
 type: application
-version: 3.8.0
-appVersion: "3.8.0"
+version: 3.8.1
+appVersion: "3.8.1"
 home: https://github.com/eclipse-iofog/iofog-operator
 sources:
   - https://github.com/eclipse-iofog/iofog-operator

--- a/charts/iofog-operator/values.yaml
+++ b/charts/iofog-operator/values.yaml
@@ -84,9 +84,9 @@ controlplane:
 
     # --- images ---
     images:
-      controller: "ghcr.io/datasance/controller:3.8.0"
-      router: "ghcr.io/datasance/router:3.8.0"
-      nats: "ghcr.io/datasance/nats:2.14.3"
+      controller: "ghcr.io/datasance/controller:3.8.1"
+      router: "ghcr.io/datasance/router:3.8.1"
+      nats: "ghcr.io/datasance/nats:2.14.3-1"
       # pullSecret: ""
 
     # --- services ---

--- a/docs/helm/datasance-helm-deprecation-README.md
+++ b/docs/helm/datasance-helm-deprecation-README.md
@@ -2,7 +2,7 @@
 
 > **Copy this file to [Datasance/helm](https://github.com/Datasance/helm) `README.md` in a separate PR** (final v3.7.2 redirect). Do not publish from this repo.
 
-The standalone [Datasance/helm](https://github.com/Datasance/helm) repository is **deprecated** as of ioFog Operator **v3.8.0**. Charts are maintained in-repo and published from each product mirror on release tags.
+The standalone [Datasance/helm](https://github.com/Datasance/helm) repository is **deprecated** as of ioFog Operator **v3.8.1**. Charts are maintained in-repo and published from each product mirror on release tags.
 
 ## Use the new Helm repository
 
@@ -16,7 +16,7 @@ helm repo add iofog-operator https://datasance.github.io/iofog-operator
 helm repo update
 helm install pot iofog-operator/iofog-operator \
   --namespace iofog-system --create-namespace \
-  --version 3.8.0 \
+  --version 3.8.1 \
   --set controlplane.spec.auth.bootstrap.password='ReplaceMe1!'
 ```
 
@@ -24,7 +24,7 @@ Documentation: [charts/iofog-operator/README.md](https://github.com/Datasance/io
 
 ## Migration from v3.7 (`datasance/pot`)
 
-**v3.8.0 is greenfield** - there is no supported in-place upgrade from the legacy `pot` chart or Keycloak-shaped `auth` values.
+**v3.8.1 is greenfield** - there is no supported in-place upgrade from the legacy `pot` chart or Keycloak-shaped `auth` values.
 
 1. Uninstall the v3.7 release and remove legacy CRDs if no longer needed.
 2. Rewrite ControlPlane auth for embedded or external OIDC (see operator README / CHANGELOG).

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/eclipse-iofog/iofog-operator/v3
 
-go 1.26.4
+go 1.26.5
 
 require (
-	github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.0
+	github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.1
 	github.com/go-logr/logr v1.4.2
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.32.1

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.0 h1:35YxSBL/Lqr7pU+KHRFgAGSxfBz2Ptn/vsqlXXgm8b0=
-github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.0/go.mod h1:9ae5lnGma/LDsrW/25QOt4aQ3pC9aM0c3ut3N3BwDWM=
+github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.1 h1:bjy4FvkEcKS+td/1zIVgWUjJFQVxkXiI6P/JCXrXlRA=
+github.com/eclipse-iofog/iofog-go-sdk/v3 v3.8.1/go.mod h1:yuTviLS8Z4MM7glAugZV+gwzjSxKFiKPDLA74GxFba4=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=


### PR DESCRIPTION
Align operator, controller, router, and NATS default image tags to the 3.8.1 train; fix NATS to 2.14.3-1. Bump Go to 1.26.5 and iofog-go-sdk to v3.8.1. Refresh Helm chart, OLM bundle, Makefile, CI, and docs; add CHANGELOG entry for 3.8.1.