### PR TITLE
chore(release): align router and NATS defaults to 3.8.2 train

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.8.2] - 2026-07-23
+## [3.8.2] - 2026-07-25
 
 ### Changed
 
 - **iofog-go-sdk** - bumped to **`github.com/eclipse-iofog/iofog-go-sdk/v3@v3.8.2`**.
-- **Default component image tags** - operator and controller **3.8.2**; router **3.8.1**; NATS **2.14.3-1** (Makefile `LDFLAGS`, Helm `values.yaml`, OLM bundle CSV).
+- **Default component image tags** - operator and controller **3.8.2**; router **3.8.2**; NATS **2.14.3-2** (Makefile `LDFLAGS`, Helm `values.yaml`, OLM bundle CSV).
 - **Release packaging** - Helm chart `version` / `appVersion`, `VERSION_TAG` defaults, and install docs updated to **3.8.2**.
 - **Container base image** - refreshed UBI9 minimal digest in `Dockerfile`.
 

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ OPERATOR_CRD_GROUP ?= iofog.org
 OPERATOR_COMPONENT_LABEL_DOMAIN ?= iofog.org
 IMAGE_REGISTRY ?= ghcr.io/eclipse-iofog
 
-# Default component image tags (RFC R10: ghcr.io/eclipse-iofog/*:3.8.1)
+# Default component image tags (RFC R10: ghcr.io/eclipse-iofog/*:3.8.2)
 CONTROLLER_IMAGE_TAG ?= 3.8.2
-ROUTER_IMAGE_TAG ?= 3.8.1
-NATS_IMAGE_TAG ?= 2.14.3-1
+ROUTER_IMAGE_TAG ?= 3.8.2
+NATS_IMAGE_TAG ?= 2.14.3-2
 
 LDFLAGS += -X $(PREFIX).routerTag=$(ROUTER_IMAGE_TAG)
 LDFLAGS += -X $(PREFIX).controllerTag=$(CONTROLLER_IMAGE_TAG)

--- a/bundle/manifests/iofog-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/iofog-operator.clusterserviceversion.yaml
@@ -48,7 +48,7 @@ metadata:
             },
             "images": {
               "controller": null,
-              "nats": "ghcr.io/datasance/nats:2.14.3-1",
+              "nats": "ghcr.io/datasance/nats:2.14.3-2",
               "pullSecret": null,
               "router": null
             },
@@ -119,7 +119,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-07-22T09:18:14Z"
+    createdAt: "2026-07-25T09:08:37Z"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: iofog-operator.v3.8.2

--- a/charts/iofog-operator/values.yaml
+++ b/charts/iofog-operator/values.yaml
@@ -85,8 +85,8 @@ controlplane:
     # --- images ---
     images:
       controller: "ghcr.io/datasance/controller:3.8.2"
-      router: "ghcr.io/datasance/router:3.8.1"
-      nats: "ghcr.io/datasance/nats:2.14.3-1"
+      router: "ghcr.io/datasance/router:3.8.2"
+      nats: "ghcr.io/datasance/nats:2.14.3-2"
       # pullSecret: ""
 
     # --- services ---


### PR DESCRIPTION
Bump router to 3.8.2 and NATS to 2.14.3-2 across Makefile LDFLAGS, Helm values, sample ControlPlane manifest, and OLM bundle CSV; update CHANGELOG entry for 3.8.2.