### PR TITLE
chore(release): bump to 3.8.3-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.3-rc.2] - 2026-08-26
+
+### Changed
+
+- **Default component image tags** - operator, controller, and router **3.8.3-rc.2**; NATS **2.14.5-rc.1** (Makefile `LDFLAGS`, Helm `values.yaml` / `values.schema.json`, sample CRs, testdata, OLM bundle CSV, `hack/package-helm.sh`).
+- **Container base image** - refreshed UBI9 minimal digest in `Dockerfile`.
+- **Helm schema defaults** - controller/router/NATS image defaults aligned with the **3.8.3-rc.2** train.
+
+### Security
+
+- **gorilla/websocket** - bumped indirect dependency to **`v1.5.3`** (from **`v1.5.0`**) to address **GO-2026-6278** (cryptographically weak PRNG for WebSocket mask key), reported by `govulncheck` via the embedded Controller login HTTP client path (`internal/auth/controllerlogin/embedded.go`).
+
 ## [3.8.3-rc.1] - 2026-08-21
 
 ### Changed
@@ -203,7 +215,8 @@ See [README.md](README.md) for install examples and dual-mirror workflow.
 - Consolidate usage of iofog client and reorganize controller reconciliation
 - Removes all references to Connector
 
-[Unreleased]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.8.3-rc.1...HEAD
+[Unreleased]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.8.3-rc.2...HEAD
+[3.8.3-rc.2]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.8.3-rc.1...v3.8.3-rc.2
 [3.8.3-rc.1]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.8.2...v3.8.3-rc.1
 [3.8.2]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.8.1...v3.8.2
 [3.8.1]: https://github.com/eclipse-iofog/iofog-operator/compare/v3.8.0...v3.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY ./hack/ ./hack/
 RUN make build
 RUN cp ./bin/iofog-operator /bin
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8@sha256:580752f96d36c4132bffd30f9c34865bf4bd87f6aa161c969d117f21732e50f7
 WORKDIR /
 
 ARG OCI_SOURCE_REPO=https://github.com/eclipse-iofog/iofog-operator

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ OPERATOR_CRD_GROUP ?= iofog.org
 OPERATOR_COMPONENT_LABEL_DOMAIN ?= iofog.org
 IMAGE_REGISTRY ?= ghcr.io/eclipse-iofog
 
-# Default component image tags (RFC R10: ghcr.io/eclipse-iofog/*:3.8.3-rc.1)
-CONTROLLER_IMAGE_TAG ?= 3.8.3-rc.1
-ROUTER_IMAGE_TAG ?= 3.8.3-rc.1
+# Default component image tags
+CONTROLLER_IMAGE_TAG ?= 3.8.3-rc.2
+ROUTER_IMAGE_TAG ?= 3.8.3-rc.2
 NATS_IMAGE_TAG ?= 2.14.5-rc.1
 
 LDFLAGS += -X $(PREFIX).routerTag=$(ROUTER_IMAGE_TAG)
@@ -45,7 +45,7 @@ GOARGS=-gcflags="all=-N -l"
 endif
 
 # Image URL to use all building/pushing image targets
-VERSION_TAG ?= 3.8.3-rc.1
+VERSION_TAG ?= 3.8.3-rc.2
 IMG ?= $(IMAGE_REGISTRY)/operator:$(VERSION_TAG)
 BUNDLE_IMG ?= $(IMAGE_REGISTRY)/operator-bundle:$(VERSION_TAG)
 BUNDLE_PACKAGE ?= iofog-operator

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ helm repo add iofog-operator https://eclipse-iofog.github.io/iofog-operator
 helm repo update
 helm install iofog-operator iofog-operator/iofog-operator \
   --namespace iofog-system --create-namespace \
-  --version 3.8.3-rc.1
+  --version 3.8.3-rc.2
 ```
 
 ### Manifest tarballs
@@ -74,7 +74,7 @@ helm install iofog-operator iofog-operator/iofog-operator \
 GitHub Releases attach flavor-specific tarballs: `manifests-iofog-<version>.tar.gz` and `manifests-datasance-<version>.tar.gz`.
 
 ```bash
-VERSION=3.8.3-rc.1
+VERSION=3.8.3-rc.2
 FLAVOR=iofog   # or datasance
 
 curl -fsSL -o manifests.tar.gz \
@@ -92,7 +92,7 @@ OLM bundles are published as container images (`operator-bundle:<version>`). Pac
 
 ```bash
 # Cluster must have OLM installed (Operator Lifecycle Manager)
-VERSION=3.8.3-rc.1
+VERSION=3.8.3-rc.2
 REGISTRY=ghcr.io/eclipse-iofog   # or ghcr.io/datasance
 
 operator-sdk run bundle "${REGISTRY}/operator-bundle:${VERSION}" \

--- a/apis/controlplanes/v3/testdata/controlplane-ref.yaml
+++ b/apis/controlplanes/v3/testdata/controlplane-ref.yaml
@@ -36,9 +36,9 @@ spec:
     cleanupInterval: 3600
     captureIpAddress: true
   images:
-    controller: ghcr.io/datasance/controller:v3.8.0
-    router: ghcr.io/datasance/router:v3.8.0
-    nats: ghcr.io/datasance/nats:2.14.3
+    controller: ghcr.io/datasance/controller:3.8.3-rc.2
+    router: ghcr.io/datasance/router:3.8.3-rc.2
+    nats: ghcr.io/datasance/nats:2.14.5-rc.1
   nats:
     enabled: true
     jetStream:

--- a/bundle/manifests/iofog-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/iofog-operator.clusterserviceversion.yaml
@@ -119,10 +119,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-08-21T07:38:03Z"
+    createdAt: "2026-08-26T15:01:51Z"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: iofog-operator.v3.8.3-rc.1
+  name: iofog-operator.v3.8.3-rc.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -170,7 +170,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: iofog-operator
-                image: ghcr.io/eclipse-iofog/operator:3.8.3-rc.1
+                image: ghcr.io/eclipse-iofog/operator:3.8.3-rc.2
                 imagePullPolicy: Always
                 name: iofog-operator
                 resources: {}
@@ -196,4 +196,4 @@ spec:
   minKubeVersion: 1.18.0
   provider:
     name: Datasance
-  version: 3.8.3-rc.1
+  version: 3.8.3-rc.2

--- a/charts/iofog-operator/Chart.yaml
+++ b/charts/iofog-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: iofog-operator
 description: Helm chart for the ioFog operator and ControlPlane
 type: application
-version: 3.8.3-rc.1
-appVersion: "3.8.3-rc.1"
+version: 3.8.3-rc.2
+appVersion: "3.8.3-rc.2"
 home: https://github.com/eclipse-iofog/iofog-operator
 sources:
   - https://github.com/eclipse-iofog/iofog-operator

--- a/charts/iofog-operator/values.schema.json
+++ b/charts/iofog-operator/values.schema.json
@@ -357,9 +357,9 @@
               "description": "Container images for Controller, Router, and NATS.",
               "properties": {
                 "pullSecret": { "type": "string", "title": "Pull Secret" },
-                "controller": { "type": "string", "title": "Controller Image", "default": "ghcr.io/datasance/controller:3.8.0" },
-                "router": { "type": "string", "title": "Router Image", "default": "ghcr.io/datasance/router:3.8.0" },
-                "nats": { "type": "string", "title": "NATS Image", "default": "ghcr.io/datasance/nats:2.14.3" }
+                "controller": { "type": "string", "title": "Controller Image", "default": "ghcr.io/datasance/controller:3.8.3-rc.2" },
+                "router": { "type": "string", "title": "Router Image", "default": "ghcr.io/datasance/router:3.8.3-rc.2" },
+                "nats": { "type": "string", "title": "NATS Image", "default": "ghcr.io/datasance/nats:2.14.5-rc.1" }
               }
             },
             "services": {

--- a/charts/iofog-operator/values.yaml
+++ b/charts/iofog-operator/values.yaml
@@ -84,9 +84,9 @@ controlplane:
 
     # --- images ---
     images:
-      controller: "ghcr.io/datasance/controller:3.8.3-rc.1"
-      router: "ghcr.io/datasance/router:3.8.3-rc.1"
-      nats: "ghcr.io/datasance/nats:2.14.3-2"
+      controller: "ghcr.io/datasance/controller:3.8.3-rc.2"
+      router: "ghcr.io/datasance/router:3.8.3-rc.2"
+      nats: "ghcr.io/datasance/nats:2.14.5-rc.1"
       # pullSecret: ""
 
     # --- services ---

--- a/config/cr/local/controlplane.yaml
+++ b/config/cr/local/controlplane.yaml
@@ -48,9 +48,9 @@ spec:
     #   id: controller
     #   secret: ""
   images:
-    controller: ghcr.io/datasance/controller:3.8.0
-    router: ghcr.io/datasance/router:3.8.0
-    nats: ghcr.io/datasance/nats:2.14.3
+    controller: ghcr.io/datasance/controller:3.8.3-rc.2
+    router: ghcr.io/datasance/router:3.8.3-rc.2
+    nats: ghcr.io/datasance/nats:2.14.5-rc.1
   nats:
     enabled: true
     jetStream:

--- a/docs/helm/datasance-helm-deprecation-README.md
+++ b/docs/helm/datasance-helm-deprecation-README.md
@@ -2,7 +2,7 @@
 
 > **Copy this file to [Datasance/helm](https://github.com/Datasance/helm) `README.md` in a separate PR** (final v3.7.2 redirect). Do not publish from this repo.
 
-The standalone [Datasance/helm](https://github.com/Datasance/helm) repository is **deprecated** as of ioFog Operator **v3.8.3-rc.1**. Charts are maintained in-repo and published from each product mirror on release tags.
+The standalone [Datasance/helm](https://github.com/Datasance/helm) repository is **deprecated** as of ioFog Operator **v3.8.3-rc.2**. Charts are maintained in-repo and published from each product mirror on release tags.
 
 ## Use the new Helm repository
 
@@ -16,7 +16,7 @@ helm repo add iofog-operator https://datasance.github.io/iofog-operator
 helm repo update
 helm install pot iofog-operator/iofog-operator \
   --namespace iofog-system --create-namespace \
-  --version 3.8.3-rc.1 \
+  --version 3.8.3-rc.2 \
   --set controlplane.spec.auth.bootstrap.password='ReplaceMe1!'
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/hack/package-helm.sh
+++ b/hack/package-helm.sh
@@ -12,7 +12,7 @@ VERSION="${2:-}"
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-}"
 OPERATOR_CRD_GROUP="${OPERATOR_CRD_GROUP:-}"
 LINT_ONLY="${LINT_ONLY:-}"
-NATS_IMAGE_TAG="${NATS_IMAGE_TAG:-2.14.3}"
+NATS_IMAGE_TAG="${NATS_IMAGE_TAG:-2.14.5-rc.1}"
 
 if [[ -z "$FLAVOR" || -z "$VERSION" ]]; then
 	echo "usage: IMAGE_REGISTRY=... OPERATOR_CRD_GROUP=... $0 <datasance|iofog> <version>" >&2


### PR DESCRIPTION
Fix GO-2026-6278 by bumping indirect gorilla/websocket to v1.5.3. Align operator, controller, and router defaults to 3.8.3-rc.2 and NATS to 2.14.5-rc.1 across Makefile, Helm, samples, testdata, and OLM bundle; refresh UBI9 base digest and update install docs; add CHANGELOG entry for 3.8.3-rc.2.